### PR TITLE
Remove the deprecated Remote option

### DIFF
--- a/docs/tools/chrome-debugger.html
+++ b/docs/tools/chrome-debugger.html
@@ -870,11 +870,9 @@ a possible launch:</p>
 
 <pre><code>String port = "4242";
 String path = java.util.UUID.randomUUID().toString();
-String remoteConnect = "true";
 Context context = Context.newBuilder("js")
             .option("inspect", port)
             .option("inspect.Path", path)
-            .option("inspect.Remote", remoteConnect)
             .build();
 String hostAdress = "localhost";
 String url = String.format(


### PR DESCRIPTION
Hi, I saw the error message as follows when I run the sample program described in [the "Programmatic Launch of Inspector Backend" section of the Chrome Debugger web page in GraalVM website](https://www.graalvm.org/docs/tools/chrome-debugger#programmatic-launch-of-inspector-backend).

```java
import org.graalvm.polyglot.*;

class DebuggerSample {
    public static void main(String... args) {
        String port = "4242";
        String path = java.util.UUID.randomUUID().toString();
        String remoteConnect = "true";
        Context context = Context.newBuilder("js")
                    .option("inspect", port)
                    .option("inspect.Path", path)
                    .option("inspect.Remote", remoteConnect)
                    .build();
        String hostAdress = "localhost";
        String url = String.format(
                    "chrome-devtools://devtools/bundled/js_app.html?ws=%s:%s/%s",
                    hostAdress, port, path);
    }
} 
```

```
Exception in thread "main" java.lang.IllegalArgumentException: Could not find option with name inspect.Remote.
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineException.illegalArgument(PolyglotEngineException.java:122)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.OptionValuesImpl.failNotFound(OptionValuesImpl.java:283)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.OptionValuesImpl.failNotFound(OptionValuesImpl.java:263)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.OptionValuesImpl.findDescriptor(OptionValuesImpl.java:240)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.OptionValuesImpl.put(OptionValuesImpl.java:142)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.OptionValuesImpl.putAll(OptionValuesImpl.java:137)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineImpl.createInstruments(PolyglotEngineImpl.java:417)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineImpl.<init>(PolyglotEngineImpl.java:266)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotEngineImpl.<init>(PolyglotEngineImpl.java:189)
        at org.graalvm.truffle/com.oracle.truffle.polyglot.PolyglotImpl.buildEngine(PolyglotImpl.java:211)
        at org.graalvm.sdk/org.graalvm.polyglot.Engine$Builder.build(Engine.java:529)
        at org.graalvm.sdk/org.graalvm.polyglot.Context$Builder.build(Context.java:1489)
        at DebuggerSample.main(DebuggerSample.java:12) 
```

I found out a commit that removed the Remote option in Graal repository.

* [GR-13781] Remove the deprecated Remote option. 
https://github.com/oracle/graal/commit/acf073ee29df3a85e458da5f774ff82a83d71bf5

So I remove some code in that sample program. After that, we can run the sample program.

```java
import org.graalvm.polyglot.*;

class DebuggerSample {
    public static void main(String... args) {
        String port = "4242";
        String path = java.util.UUID.randomUUID().toString();
        Context context = Context.newBuilder("js")
                    .option("inspect", port)
                    .option("inspect.Path", path)
                    .build();
        String hostAdress = "localhost";
        String url = String.format(
                    "chrome-devtools://devtools/bundled/js_app.html?ws=%s:%s/%s",
                    hostAdress, port, path);
    }
} 
```

```
$ java DebuggerSample
Debugger listening on port 4242.
To start debugging, open the following URL in Chrome:
    chrome-devtools://devtools/bundled/js_app.html?ws=127.0.0.1:4242/0d124e3a-aed4-41d8-94d7-da0b886312d2 
```

I also found the Remote option in docs/search/index.html, but it seems to be automatically generated. So I leave it as it.

For your information, my company (NTT Data Corporation) signed OCA and I've contributed to GraalVM repository before.