### PR TITLE
Add RESTHeart to list of Ready for Native Image Frameworks

### DIFF
--- a/native-image/libraries-and-frameworks/index.html
+++ b/native-image/libraries-and-frameworks/index.html
@@ -287,6 +287,15 @@ For more details on what they offer, please refer to their project launchers.</p
   </tr>
 </thead>
 <tbody>
+<td class="tg artifact">
+    <a href="https://restheart.org" target="_blank">RESTHeart</a>
+</td>
+<td class="tg">
+    <a href="https://github.com/SoftInstigate/restheart-plugin-skeleton" target="_blank">RESTHeart Plugin Skeleton</a>
+</td>
+<td class="tg">framework</td>
+</tr>
+<tr>
 <tr>
 <td class="tg artifact">
     <a href="https://helidon.io" target="_blank">Helidon</a>


### PR DESCRIPTION
This PR adds RESTHeart to the list of Ready for Native Image Frameworks in https://www.graalvm.org/native-image/libraries-and-frameworks/